### PR TITLE
Bug 97 handling of duplicate job ids

### DIFF
--- a/src/Service/JobArchive.php
+++ b/src/Service/JobArchive.php
@@ -78,9 +78,9 @@ class JobArchive {
     public function getData($job)
     {
         $path = $this->getJobDirectory($job).'/data.json';
-        $data = file_get_contents($path);
+        $data = @file_get_contents($path);
 
-        if (!$data) {
+        if ($data === false) {
             $legacyPath = $this->getLegacyJobDirectory($job).'/data.json';
             $data = file_get_contents($legacyPath);
         }
@@ -91,9 +91,9 @@ class JobArchive {
     public function getMeta($job)
     {
         $path = $this->getJobDirectory($job).'/meta.json';
-        $data = file_get_contents($path);
+        $data = @file_get_contents($path);
 
-        if (!$data) {
+        if ($data === false) {
             $legacyPath = $this->getLegacyJobDirectory($job).'/meta.json';
             $data = file_get_contents($legacyPath);
         }

--- a/src/Service/JobArchive.php
+++ b/src/Service/JobArchive.php
@@ -47,6 +47,17 @@ class JobArchive {
     public function getJobDirectory($job)
     {
         $jobId = intval(explode('.', $job->getJobId())[0]);
+        $jobStart = intval($job->getStartTime());
+        $lvl1 = intdiv($jobId, 1000);
+        $lvl2 = $jobId % 1000;
+        $path = sprintf('%s/%s/%d/%03d/%d',
+            $this->_rootdir, $job->getClusterId(), $lvl1, $lvl2, $jobStart);
+        return $path;
+    }
+
+    public function getLegacyJobDirectory($job)
+    {
+        $jobId = intval(explode('.', $job->getJobId())[0]);
         $lvl1 = intdiv($jobId, 1000);
         $lvl2 = $jobId % 1000;
         $path = sprintf('%s/%s/%d/%03d/',
@@ -59,10 +70,21 @@ class JobArchive {
         return file_exists($this->getJobDirectory($job).'/data.json');
     }
 
+    public function isLegacyArchived($job)
+    {
+        return file_exists($this->getLegacyJobDirectory($job).'/data.json');
+    }
+
     public function getData($job)
     {
         $path = $this->getJobDirectory($job).'/data.json';
         $data = file_get_contents($path);
+
+        if (!$data) {
+            $legacyPath = $this->getLegacyJobDirectory($job).'/data.json';
+            $data = file_get_contents($legacyPath);
+        }
+
         return json_decode($data, true);
     }
 
@@ -70,6 +92,12 @@ class JobArchive {
     {
         $path = $this->getJobDirectory($job).'/meta.json';
         $data = file_get_contents($path);
+
+        if (!$data) {
+            $legacyPath = $this->getLegacyJobDirectory($job).'/meta.json';
+            $data = file_get_contents($legacyPath);
+        }
+
         return json_decode($data, true);
     }
 

--- a/src/Service/JobData.php
+++ b/src/Service/JobData.php
@@ -66,6 +66,11 @@ class JobData
 
         $job->hasProfile = $this->_jobArchive->isArchived($job);
 
+        // Backwards compatibility
+        if (!$job->hasProfile){
+            $job->hasProfile = $this->_jobArchive->isLegacyArchived($job);
+        }
+
         if (!$job->hasProfile){
             $this->_metricDataRepository->hasProfile($job,
                 $this->_clusterCfg->getSingleMetric($job->getClusterId()));

--- a/src/Service/JobStats.php
+++ b/src/Service/JobStats.php
@@ -84,7 +84,7 @@ class JobStats
             $res[$idx] = [ 'name' => $metric, 'footprints' => [] ];
 
         foreach ($jobs as $job) {
-            if ($this->_jobArchive->isArchived($job)) {
+            if ($this->_jobArchive->isArchived($job) || $this->_jobArchive->isLegacyArchived($job)) {
                 $stats = $this->_jobArchive->getMeta($job)['statistics'];
                 foreach ($metrics as $idx => $metric) {
                     if (isset($stats[$metric]))


### PR DESCRIPTION
Added third layer in job-archive folder structure based on job starttime. Backwards-compatible implementation for existing archived jobs.

* Newly archived jobs are always use third layer `cluster/lvl1/lvl2/starttime` when written.
* When checking existence of or loading from archived data, new structure is queried first.
* Fallback to `cluster/lvl1/lvl2` structure if no data returned by first query.

Closes #97 